### PR TITLE
Server anvil recipes superseed client recipes. (TFC-0.79.18+)

### DIFF
--- a/src/java/sladki/tfc/Handlers/ChunkEventHandler.java
+++ b/src/java/sladki/tfc/Handlers/ChunkEventHandler.java
@@ -1,5 +1,6 @@
 package sladki.tfc.Handlers;
 
+import com.bioxx.tfc.Core.Recipes;
 import net.minecraftforge.event.world.WorldEvent;
 import sladki.tfc.ModManager;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -8,7 +9,7 @@ public class ChunkEventHandler {
 
 	@SubscribeEvent
 	public void onLoadWorld(WorldEvent.Load event) {
-		if(event.world.provider.dimensionId == 0) {
+		if(!event.world.isRemote && event.world.provider.dimensionId == 0 ) {
 			ModManager.registerAnvilRecipes();
 		}
 	}


### PR DESCRIPTION
Do not register anvil recipes on a server.
